### PR TITLE
Fix word-boundary character duplication

### DIFF
--- a/src/jisonlex.jison
+++ b/src/jisonlex.jison
@@ -106,7 +106,7 @@ action
 regex
     : regex_list 
         {{ $$ = $1; 
-          if ($$.match(/[\w\d]$/) && !$$.match(/\\u[a-fA-F0-9]{4}$/))
+          if ($$.match(/[\w\d]$/) && !$$.match(/\\u[a-fA-F0-9]{4}$/) && !$$.match(/\\b$/))
               $$ += "\\b";
         }}
     ;


### PR DESCRIPTION
I noticed that if `\b` is explicitly added to the end of a pattern in the lexfile, jison adds an additional `\b` to the JavaScript regex it compiles (so this then ends in `\b\b`). In most cases this is irrelevant and causes no problems, but I added an additional condition to stop the behavior, nonetheless.
