### PR TITLE
Change description of relation Jisonlex--Flex 

### DIFF
--- a/web/content/docs.html
+++ b/web/content/docs.html
@@ -292,7 +292,7 @@ Lexical Analysis
 ----------------
 Jison includes a rather rudimentary scanner generator, though **any module that supports the basic scanner API could be used** in its place. 
 
-The format of the [input file](http://dinosaur.compilertools.net/flex/flex_6.html#SEC6) (including macro support) and the style of the [pattern matchers](http://dinosaur.compilertools.net/flex/flex_7.html#SEC7) are modeled after Flex. It is a subset, so there are some differences, namely exact string patterns must be placed in quotes e.g.:
+The format of the [input file](http://dinosaur.compilertools.net/flex/flex_6.html#SEC6) (including macro support) and the style of the [pattern matchers](http://dinosaur.compilertools.net/flex/flex_7.html#SEC7) are modeled after Flex. Several [metacharacters have been added](https://github.com/zaach/jison/wiki/DeviationsFromBison), but there is also one minor inconvenience compared to Flex patterns, namely exact string patterns must be placed in quotes e.g.:
 
 Bad:
 


### PR DESCRIPTION
The description of the Jison format as a subset of the Flex format is no longer accurate.
I also added documentation for the additions in the wiki.
