### PR TITLE
update nomnom dependency to require exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": "0.4 || 0.5"
   },
   "dependencies": {
-    "nomnom": ">= 0.4.3"
+    "nomnom": "0.4.3"
   },
   "devDependencies": {
     "test": "*",


### PR DESCRIPTION
I just pushed nomnom 1.0 to npm. It had some api-breaking changes, so I checkout out the packages that depend on it. I think the new version would break this one, mainly that you'd have to specify 'flag: true' for any boolean options like '--version'.

This just takes the '>=' out of the package.json dep listing.
