### PR TITLE
Get parsed symbol when unexpected input pops up

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1092,7 +1092,7 @@ parser.parse = function parse (input) {
                 }
                 var errStr = '';
                 if (this.lexer.showPosition) {
-                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ');
+                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
                 } else {
                     errStr = 'Parse error on line '+(yylineno+1)+": Unexpected " +
                                   (symbol == 1 /*EOF*/ ? "end of input" :


### PR DESCRIPTION
This is just a little feature request.

I think it would be nice to know what symbol the lexer actually got when unexpected input pops up.

Just an example: now, we have:

```
Parse error on line 1: foobar ^ Expecting 'CREATOR_T', 'VERSION_T'
```

So I modified it a bit to get:

```
Expecting 'CREATOR_T', 'VERSION_T', got 'NO_NEW_LINE_CHAR'
```
