### PR TITLE
fix for issue #64 when handling files with CRLF line breaks

### DIFF
--- a/lib/jison/cli-wrapper.js
+++ b/lib/jison/cli-wrapper.js
@@ -42,6 +42,7 @@ exports.main = function (argv) {
         var raw = IO.read(IO.join(IO.cwd(),args.file)),
             name = IO.basename((args.outfile||args.file)).replace(/\..*$/g,''),
             lex;
+        raw = raw.replace(/\r\n/g, '\n');
         if (args.lexfile) {
             lex = IO.read(IO.join(IO.cwd(),args.lexfile));
         }


### PR DESCRIPTION
As explained on https://github.com/zaach/jison/issues/64
