### PR TITLE
Minor changes to clean up warning in node v0.6 

### DIFF
--- a/lib/jison/util/bnf-parser.js
+++ b/lib/jison/util/bnf-parser.js
@@ -163,7 +163,7 @@ parse: function parse(input) {
                 }
                 var errStr = '';
                 if (this.lexer.showPosition) {
-                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ');
+                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
                 } else {
                     errStr = 'Parse error on line '+(yylineno+1)+": Unexpected " +
                                   (symbol == 1 /*EOF*/ ? "end of input" :

--- a/lib/jison/util/io.js
+++ b/lib/jison/util/io.js
@@ -3,9 +3,9 @@
 if (typeof process !== 'undefined') {
 
 var fs = require('fs');
-var sys = require('sys');
+var util = require('util');
 
-exports.p = sys.puts;
+exports.p = util.puts;
 exports.cwd = process.cwd;
 exports.join = require('path').join;
 exports.basename = require('path').basename;

--- a/lib/jison/util/lex-parser.js
+++ b/lib/jison/util/lex-parser.js
@@ -190,7 +190,7 @@ parse: function parse(input) {
                 }
                 var errStr = '';
                 if (this.lexer.showPosition) {
-                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ');
+                    errStr = 'Parse error on line '+(yylineno+1)+":\n"+this.lexer.showPosition()+'\nExpecting '+expected.join(', ') + ", got '" + this.terminals_[symbol]+ "'";
                 } else {
                     errStr = 'Parse error on line '+(yylineno+1)+": Unexpected " +
                                   (symbol == 1 /*EOF*/ ? "end of input" :

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "json2jison": "lib/jison/json2jison.js"
   },
   "engines": {
-    "node": "0.4 || 0.5"
+    "node": ">=0.4.0"
   },
   "dependencies": {
     "nomnom": "0.4.3"


### PR DESCRIPTION
This commit fixes the following warning with node V0.6:

> The "sys" module is now called "util". It should have a similar interface.

There was also a bump in the packages engine version number.
