### PR TITLE
TypeError when a  moduleName isn't supplied to "generate"

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -875,7 +875,7 @@ lrGeneratorMixin.generate = function parser_generate (opt) {
     var code = "";
 
     // check for illegal identifier
-    if (!opt.moduleName.match(/^[A-Za-z_$][A-Za-z0-9_$]*$/)) {
+    if (!opt.moduleName || !opt.moduleName.match(/^[A-Za-z_$][A-Za-z0-9_$]*$/)) {
         opt.moduleName = "parser";
     }
     switch (opt.moduleType) {


### PR DESCRIPTION
I'm working on a language called Roy. A couple of users ran into a Jison problem when installing it:

https://github.com/pufuwozu/roy/issues/95

My parser is generated with the following line of code:

```
fs.writeFile('src/typeparser.js', parser.generate());
```

I don't supply any opts. Before this change we didn't check if `opts.moduleName` was `undefined` which caused a `TypeError`.

Thanks!
