### PR TITLE
For Master Branch: Added a new moduleType: 'amd' which causes Jison to generate AMD modules...

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For more information on creating grammars and using the generated parsers, read 
 
 How to contribute
 -----------------
-Fork the integration branch, make your changes, run tests and/or add tests then send a pull request.
+Fork, make your changes, run tests and/or add tests then send a pull request.
 
 Run tests with:
 

--- a/lib/jison.js
+++ b/lib/jison.js
@@ -882,12 +882,26 @@ lrGeneratorMixin.generate = function parser_generate (opt) {
         case "js":
             code = this.generateModule(opt);
         break;
+        case "amd":
+            code = this.generateAMDModule(opt);
+        break;
         case "commonjs":
         default:
             code = this.generateCommonJSModule(opt);
     }
 
     return code;
+};
+
+lrGeneratorMixin.generateAMDModule = function generateAMDModule(opt){
+    opt = typal.mix.call({}, this.options, opt);
+    var out = 'define([], function(){'
+        + '\nvar parser = '+ this.generateModule_(opt)
+        + '\n' + this.lexer.generateModule()
+        + '\nparser.lexer = lexer;'
+        + '\nreturn parser;'
+        + '\n});'
+    return out;
 };
 
 lrGeneratorMixin.generateCommonJSModule = function generateCommonJSModule (opt) {

--- a/tests/parser/generator.js
+++ b/tests/parser/generator.js
@@ -2,7 +2,37 @@ var Jison = require("../setup").Jison,
     Lexer = require("../setup").Lexer,
     assert = require("assert");
 
+exports["test amd module generator"] = function() {
+    var lexData = {
+        rules: [
+           ["x", "return 'x';"],
+           ["y", "return 'y';"]
+        ]
+    };
+    var grammar = {
+        tokens: "x y",
+        startSymbol: "A",
+        bnf: {
+            "A" :[ 'A x',
+                   'A y',
+                   ''      ]
+        }
+    };
 
+    var input = "xyxxxy";
+    var gen = new Jison.Generator(grammar);
+    gen.lexer = new Lexer(lexData);
+
+    var parserSource = gen.generateAMDModule();
+    var parser = null,
+        define = function(deps, callback){
+            // temporary AMD-style define function, for testing.
+            parser = callback();
+        };
+    eval(parserSource);
+
+    assert.ok(parser.parse(input));
+};
 
 exports["test commonjs module generator"] = function () {
     var lexData = {


### PR DESCRIPTION
**_This is the updated pull request for master that you asked for.**_ _Additionally, I removed the instructions from README.md which tell contributors to use the integration branch :)_

Hi,

I use RequireJS on the front-end and wanted to be able to import my Jison parsers as AMD modules. I went ahead and made a new function: lrGeneratorMixin.generateAMDModule in jison.js, as well as added a check for "amd" in lrGeneratorMixin.generate.

Let me know if you have any questions.

Thanks,
Jason
