### PR TITLE
Parse error handling

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -958,7 +958,7 @@ function removeErrorRecovery (fn) {
         var ast = Reflect.parse(parseFn);
 
         var labeled = JSONSelect.match(':has(:root > .label > .name:val("_handle_error"))', ast);
-        labeled[0].body.consequent.body = [labeled[0].body.consequent.body[0]];
+        labeled[0].body.consequent.body = [labeled[0].body.consequent.body[0], labeled[0].body.consequent.body[1]];
 
         return Reflect.stringify(ast).replace(/_handle_error:\s?/,"").replace(/\\\\n/g,"\\n");
     } catch (e) {


### PR DESCRIPTION
When error recovery is not used, removeErrorRecovery also deleted parse error handling. I've fixed that.
