### PR TITLE
Style change

### DIFF
--- a/lib/jison/cli-wrapper.js
+++ b/lib/jison/cli-wrapper.js
@@ -7,11 +7,11 @@ var JISON = require('../jison'),
 var opts = [
   { name: 'file',
     position: 0,
-    help: 'Grammar file'
+    help: '\t\t\tGrammar file'
   },
   { name: 'lexfile',
     position: 1,
-    help: 'Lexical grammar file (optional)'
+    help: '\t\tLexical grammar file (optional)'
   },
   { name: 'outfile',
     string: '-o FILE, --output-file=FILE',
@@ -20,16 +20,16 @@ var opts = [
   { name: 'debug',
     string: '-t, --debug',
     "default": false,
-    help: 'Use debug mode'
+    help: '\t\tUse debug mode'
   },
   { name: 'moduleType',
     string: '-m, --module-type',
     "default": "commonjs",
-    help: 'The type of module to generate (commonjs, amd, js)'
+    help: '\tThe type of module to generate (commonjs, amd, js)'
   },
   { name: 'version',
     string: '-V, --version',
-    help: 'Version number'
+    help: '\t\tVersion number'
   }
 ];
 


### PR DESCRIPTION
I've added tabs to the command-line options descriptions, so command line options are aligned nicely.

So if previously it was like this:

```
d:\>jison --help
Usage: jison <file> <lexfile> [options]

<file>          Grammar file
<lexfile>               Lexical grammar file (optional)

options:
-o FILE, --output-file=FILE             Filename and base module name of the generated parser
-t, --debug                     Use debug mode
-m, --module-type               The type of module to generate (commonjs, amd, js)
-V, --version           Version number
```

Currently it's like this:

```
d:\>jison --help
Usage: jison <file> <lexfile> [options]

<file>                                  Grammar file
<lexfile>                               Lexical grammar file (optional)

options:
-o FILE, --output-file=FILE             Filename and base module name of the generated parser
-t, --debug                             Use debug mode
-m, --module-type                       The type of module to generate (commonjs, amd, js)
-V, --version                           Version number
```
