### PR TITLE
syntax error when not using the built-in lexer

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -941,7 +941,7 @@ lrGeneratorMixin.generateModule = function generateModule (opt) {
         out += this.lexer.generateModule();
         out += "\nparser.lexer = lexer;";
     }
-    out += "function Parser () { this.yy = {}; }"
+    out += "\nfunction Parser () { this.yy = {}; }"
         + "Parser.prototype = parser;"
         + "parser.Parser = Parser;"
         + "\nreturn new Parser;\n})();";


### PR DESCRIPTION
syntax error when not using the built-in lexer
