### PR TITLE
Update lib/jison/lexer.js

### DIFF
--- a/lib/jison/lexer.js
+++ b/lib/jison/lexer.js
@@ -193,12 +193,13 @@ RegExpLexer.prototype = {
 
         if (lines.length-1) this.yylineno -= lines.length-1;
         var r = this.yylloc.range;
+        var oldLinesLength = (oldLines[oldLines.length - lines.length] ? oldLines[oldLines.length - lines.length].length : 0);
 
         this.yylloc = {first_line: this.yylloc.first_line,
           last_line: this.yylineno+1,
           first_column: this.yylloc.first_column,
           last_column: lines ?
-              (lines.length === oldLines.length ? this.yylloc.first_column : 0) + oldLines[oldLines.length - lines.length].length - lines[0].length:
+              (lines.length === oldLines.length ? this.yylloc.first_column : 0) + oldLinesLength - lines[0].length:
               this.yylloc.first_column - len
           };
 


### PR DESCRIPTION
Odd case where oldLines[?].length didn't exist, so return a length of 0 if there is no length.
