### PR TITLE
Fix broken link to "Deviations From Flex/BIson"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -320,7 +320,7 @@ e
 <h2 id="lexical-analysis">Lexical Analysis</h2>
 <p>Jison includes a rather rudimentary scanner generator, though <strong>any module that supports the basic scanner API could be used</strong> in its place. </p>
 
-<p>The format of the <a href="http://dinosaur.compilertools.net/flex/flex_6.html#SEC6">input file</a> (including macro support) and the style of the <a href="http://dinosaur.compilertools.net/flex/flex_7.html#SEC7">pattern matchers</a> are modeled after Flex. Several <a href="https://github.com/zaach/jison/wiki/DeviationsFromBison">metacharacters have been added</a>, but there is also one minor inconvenience compared to Flex patterns, namely exact string patterns must be placed in quotes e.g.:</p>
+<p>The format of the <a href="http://dinosaur.compilertools.net/flex/flex_6.html#SEC6">input file</a> (including macro support) and the style of the <a href="http://dinosaur.compilertools.net/flex/flex_7.html#SEC7">pattern matchers</a> are modeled after Flex. Several <a href="https://github.com/zaach/jison/wiki/Deviations-From-Flex-Bison">metacharacters have been added</a>, but there is also one minor inconvenience compared to Flex patterns, namely exact string patterns must be placed in quotes e.g.:</p>
 
 <p>Bad:</p>
 


### PR DESCRIPTION
The docs had a link to the wiki page "Deviations from Bison," which has been renamed to "Deviations from Flex Bison".
