### PR TITLE
tests/lexer/regexplexer.js misspelling

### DIFF
--- a/tests/lexer/regexplexer.js
+++ b/tests/lexer/regexplexer.js
@@ -196,7 +196,7 @@ exports["test ignored"] = function() {
     assert.equal(lexer.lex(), "EOF");
 };
 
-exports["test dissambiguate"] = function() {
+exports["test disambiguate"] = function() {
     var dict = {
         rules: [
            ["for\\b", "return 'FOR';" ],


### PR DESCRIPTION
change dissambiguate to disambiguate
