### PR TITLE
Function() way of generating code breaks for slightly more complication %{...%} action snippets

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -97,7 +97,7 @@ generator.constructor = function Jison_Generator (grammar, opt) {
         }
         this.actionInclude = grammar.actionInclude;
     }
-    this.moduleInclude = grammar.moduleInclude||'';
+    this.moduleInclude = grammar.moduleInclude || '';
 
     this.DEBUG = options.debug || false;
     if (this.DEBUG) this.mix(generatorDebug); // mixin debug methods
@@ -238,7 +238,13 @@ generator.buildProductions = function buildProductions(bnf, productions, nonterm
 
     this.productions_ = productions_;
     actions.push('}');
-    this.performAction = Function("yytext,yyleng,yylineno,yy,yystate,$$,_$", actions.join("\n"));
+    // first try to create the performAction function the old way,
+    // but this will break for some legal constructs in the user action code:
+    try {
+        this.performAction = Function("yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */", actions.join("\n"));
+    } catch (e) {
+        this.performAction = "function anonymous(yytext, yyleng, yylineno, yy, yystate /* action[1] */, $$ /* vstack */, _$ /* lstack */) {\n" + actions.join("\n") + "\n}";
+    }
 
     function buildProduction (handle) {
         var r, rhs, i;


### PR DESCRIPTION
(manual extract from #143)
- (SHA-1: 47206a3350d3359a8190c6ff342c42a17bc53d55) \* patched the code generator as it broke on the offending line (where the action code is poured into a Function()) for action blocks such as this one:
  
  ... rule ...
  | TAN '(' e ')'
      {
          $$ = {
              token:      FKW_FUNCTION,
              token_attr: FKA_ABSOLUTE,
              childs:     [null, $3],
              loc_info:   @$,
              type:       FT_NUMBER,
              unit:       $3.unit,
              value:      Math.abs($3.value)
          };
      }

The object creation like that would produce a 'Unexpected symbol' error.
