### PR TITLE
Make examples/classy_ast.jison functional by adding prependChild definition

### DIFF
--- a/examples/classy_ast.jison
+++ b/examples/classy_ast.jison
@@ -1,4 +1,3 @@
-
 /* description: ClassyLang grammar with AST-building actions. Very classy. */
 /* 
   To build parser:
@@ -8,6 +7,13 @@
 */
 
 /* author: Zach Carter */
+
+%{
+    function prependChild(node, child){
+      node.splice(2,0,child); 
+      return node;
+    }
+%}
 
 %right ASSIGN
 %left OR


### PR DESCRIPTION
The definition of the prependChild function is missing from the classy_ast.jison definition. Add it based on definition in web/jison/examples/classy_ast.json
