### PR TITLE
Correcting link on documentation page

### DIFF
--- a/web/content/docs.html
+++ b/web/content/docs.html
@@ -18,7 +18,7 @@ Jison takes a context-free grammar as input and outputs a JavaScript file capabl
 * [Custom Scanners](#custom-scanners)
 * [Sharing Scope](#sharing-scope)
 * [Parsing algorithms](#parsing-algorithms)
-* [Real world examples](#real-world-examples)
+* [Projects using Jison](#projects-using-jison)
 * [Contributors](#contributors)
 * [License](#license)
  
@@ -380,7 +380,7 @@ Like Bison, Jison can recognize languages described by LALR(1) grammars, though 
 **LR(1) mode is currently not practical for use with anything other than toy grammars, but that is entirely a consequence of the algorithm used, and may change in the future.*
 
 Projects using Jison
-------------------
+--------------------
 View them on the [wiki](https://github.com/zaach/jison/wiki/ProjectsUsingJison), or add your own.
 
 Contributors


### PR DESCRIPTION
The link to the header "Real world examples" no longer exists
and that is causing the link to not work
