### PR TITLE
remove two-pass-centric anti-hybrid propaganda

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -191,7 +191,7 @@ var parserSource = parser.generate({moduleName: "myCalculator.parser"});
 </ul>
 
 <h2 id="specifying-a-language">Specifying a Language</h2>
-<p>The process of parsing a language involves two phases: <strong>lexical analysis</strong> (tokenizing) and <strong>parsing</strong>, which the Lex/Yacc and Flex/Bison combinations are famous for. Jison lets you specify a parser much like you would using Bison/Flex, with separate files for tokenization rules and for the language grammar, or with the tokenization rules embedded in the main grammar. </p>
+<p>The process of parsing a language commonly involves two phases: <strong>lexical analysis</strong> (tokenizing) and <strong>parsing</strong>, which the Lex/Yacc and Flex/Bison combinations are famous for. Jison lets you specify a parser much like you would using Bison/Flex, with separate files for tokenization rules and for the language grammar, or with the tokenization rules embedded in the main grammar. </p>
 
 <p>For example, here is the grammar for the calculator parser:</p>
 


### PR DESCRIPTION
As a sometimes fan of context-dependent grammars and languages, I was offended by the suggestion that all language parsing is done in two distinct phases. I've cleared this up so as to avoid you trouble with the perl-alike language militia, should they stumble upon this file.
