### PR TITLE
AMD module generator should be able to define dependencies

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -951,14 +951,7 @@ lrGeneratorMixin.generate = function parser_generate (opt) {
 
 lrGeneratorMixin.generateAMDModule = function generateAMDModule(opt){
     opt = typal.mix.call({}, this.options, opt);
-    opt.deps = opt.deps || [];
-    var dep_paths = "[";
-    for(var i = 0; i < opt.deps.length; i++) {
-        dep_paths += "\"" + opt.deps + "\"";
-        if(i < opt.deps.length-1) dep_paths += ",";
-    }
-    dep_paths += "]";
-    var out = '\n\ndefine('+dep_paths+', function('+opt.deps.join(',')+'){'
+    var out = '\n\ndefine(function(require){'
         + '\nvar parser = '+ this.generateModule_(opt)
         + "\n"+this.moduleInclude
         + (this.lexer && this.lexer.generateModule ?

--- a/tests/parser/generator.js
+++ b/tests/parser/generator.js
@@ -25,7 +25,7 @@ exports["test amd module generator"] = function() {
 
     var parserSource = gen.generateAMDModule();
     var parser = null,
-        define = function(deps, callback){
+        define = function(callback){
             // temporary AMD-style define function, for testing.
             parser = callback();
         };


### PR DESCRIPTION
The AMD module generator is great, but at the moment it's hardcoded to produce an empty list of dependencies.  This obviously makes it hard to integrate a Jison-generated AMD module into a larger project.

Should only take a small patch of line 954 of jison.js:
var out = '\n\ndefine('+JSON.stringify(opt.deps)+', function('+opt.deps.join(',')+'){'

If I'm correct in my assumptions, that patch would allow you to define dependencies for the generated module using the generator options by providing an array of strings.  It's a bit limited since it uses the same array for the names of the modules and their filenames, but it would be enough for most projects.
