### PR TITLE
generate({moduleName: "compiler.parser"}) creates default parser variable

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -925,7 +925,7 @@ lrGeneratorMixin.generate = function parser_generate (opt) {
     var code = "";
 
     // check for illegal identifier
-    if (!opt.moduleName || !opt.moduleName.match(/^[A-Za-z_$][A-Za-z0-9_$]*$/)) {
+    if (!opt.moduleName || !opt.moduleName.match(/^[A-Za-z_$][A-Za-z0-9_$\.]*$/)) {
         opt.moduleName = "parser";
     }
     switch (opt.moduleType) {
@@ -1788,4 +1788,3 @@ return function Parser (g, options) {
     };
 
 })();
-

--- a/tests/parser/generator.js
+++ b/tests/parser/generator.js
@@ -139,7 +139,7 @@ exports["test module generator with namespaced module name"] = function () {
     var gen = new Jison.Generator(grammar);
     gen.lexer = new Lexer(lexData);
 
-    var parserSource = gen.generateModule({moduleName: "compiler.parser"});
+    var parserSource = gen.generate({moduleName: "compiler.parser"});
     eval(parserSource);
 
     assert.ok(compiler.parser.parse(input));


### PR DESCRIPTION
When using `generate({moduleName: "compiler.parser"})`, the default `parser` variable is created in the global namespace instead of attaching to `compiler`. When checking for a valid moduleName in `generate()`, the regular expression does not include `.`. This pull request adds that to the regular expression and updates the test case to use `generate` instead of `generateModule`. 
