### PR TITLE
Reduce parser file size even more

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -197,6 +197,7 @@ generator.buildProductions = function buildProductions(bnf, productions, nonterm
       'var $0 = $$.length - 1;',
       'switch (yystate) {'
     ];
+    var actionGroups = {};
     var prods, symbol;
     var productions_ = [0];
     var symbolId = 1;
@@ -228,6 +229,8 @@ generator.buildProductions = function buildProductions(bnf, productions, nonterm
 
         prods.forEach(buildProduction);
     }
+    for (var action in actionGroups)
+      actions.push(actionGroups[action].join(' '), action, 'break;');
 
     var sym, terms = [], terms_ = {};
     each(symbols_, function (id, sym) {
@@ -271,7 +274,7 @@ generator.buildProductions = function buildProductions(bnf, productions, nonterm
 
             if (typeof handle[1] === 'string' || handle.length == 3) {
                 // semantic action specified
-                var action = 'case '+(productions.length+1)+':'+handle[1]+'\nbreak;';
+                var label = 'case ' + (productions.length+1) + ':', action = handle[1];
 
                 // replace named semantic values ($nonterminal)
                 if (action.match(/[$@][a-zA-Z][a-zA-Z0-9_]*/)) {
@@ -313,7 +316,8 @@ generator.buildProductions = function buildProductions(bnf, productions, nonterm
                     .replace(/@(-?\d+)/g, function (_, n) {
                         return "_$[$0" + (n - rhs.length || '') + "]";
                     });
-                actions.push(action);
+                if (action in actionGroups) actionGroups[action].push(label);
+                else actionGroups[action] = [label];
 
                 // done with aliases; strip them.
                 rhs = rhs.map(function(e,i) { return e.replace(/\[[a-zA-Z_][a-zA-Z0-9_-]*\]/g, '') });


### PR DESCRIPTION
### Summary

**This pull request, together with #234, more than halves the gzipped size of generated parsers.**
### Problem

The largest part of a Jison-generated parser is its `table`: a large array containing objects with numeric keys and (arrays of) numeric values.
#234 already optimized this table by tackling those cases:
1. **repeated long numerical arrays**
   _example:_ `tables = [{ 5: [1,3,4,6,7,8,15], 6: 7}, { 20: [1,3,4,6,7,8,15], 9: 8 }]`
2. **objects where all keys have the same value**
   _example:_ `tables = [{ 5: [200,204], 17: [200,204], 20: [200,204], 21: [200,204] }]`

A third optimization brings down this size even more:
3. **objects where many (but not all) keys have the same value**
_example:_ `tables = [{ 5: [200, 204], 17: [200,204], 20: [200,204], 21: 37 }]`
### Solution

Extend the translation function `o` such that it also accepts additional keys:

```
var tables = [o([5, 17, 20], [200, 204], { 21: 37 })];
```
### Results

A parser I am working on benefited significantly from the new table generation function:
- **before:** **173kb** _(generated)_, **155kb** _(minified)_, **36kb** _(gzipped)_
- **optimization 1:** **138kb** _(generated)_, **112kb** _(minified)_, **36kb** _(gzipped)_
- **optimizations 1 and 2:** **91kb** _(generated)_, **71kb** _(minified)_, **19kb** _(gzipped)_
- **optimizations 1, 2 and 3:** **76kb** _(generated)_, **57kb** _(minified)_, **16kb** _(gzipped)_

The decrease from 36kb to 19kb is a **56% reduction**.
