### PR TITLE
Fix JSON mode in the CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,11 +66,7 @@ cli.main = function cliMain(opts) {
     opts = opts || {};
 
     function processGrammar(raw, lex, opts) {
-        var grammar,
-        parser;
-        if (!opts.json) {
-            grammar = cli.processGrammars(raw, lex, opts.json);
-        }
+        var grammar = cli.processGrammars(raw, lex, opts.json),
         parser = cli.generateParserString(opts, grammar);
         return parser;
     }


### PR DESCRIPTION
This pull request removes an if statement that breaks the CLI's `--json` flag.

Here's how to reproduce the bug with jison 0.4.15:

```
$ curl -s https://raw.githubusercontent.com/zaach/jison/master/examples/calculator.json | ./node_modules/.bin/jison --json

node_modules/jison/lib/cli.js:142
    var settings = grammar.options || {};
                          ^
TypeError: Cannot read property 'options' of undefined
    at Object.generateParserString (node_modules/jison/lib/cli.js:142:27)
    at processGrammar (node_modules/jison/lib/cli.js:74:22)
    at node_modules/jison/lib/cli.js:125:25
    at Socket.<anonymous> (node_modules/jison/lib/cli.js:119:13)
    at Socket.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:910:16
    at process._tickCallback (node.js:415:13)
```

That `grammar` variable is undefined on line 142 of cli.js because of this `if (!opts.json)` check, which prevents the prerequisite call to `cli.processGrammars`.
