### PR TITLE
Stop silencing useful information.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -160,21 +160,13 @@ cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
     var ebnfParser = require('ebnf-parser');
     var cjson = require('cjson');
     var grammar;
-    try {
-        if (jsonMode) {
-            grammar = cjson.parse(file);
-        } else {
-            grammar = ebnfParser.parse(file);
-        }
-    } catch (e) {
-        throw new Error('Could not parse jison grammar');
+    if (jsonMode) {
+        grammar = cjson.parse(file);
+    } else {
+        grammar = ebnfParser.parse(file);
     }
-    try {
-        if (lexFile) {
-            grammar.lex = require('lex-parser').parse(lexFile);
-        }
-    } catch (e) {
-        throw new Error('Could not parse lex grammar');
+    if (lexFile) {
+        grammar.lex = require('lex-parser').parse(lexFile);
     }
     return grammar;
 };


### PR DESCRIPTION
The thrown errors didn't hold any useful information and made debugging
impossible.

Before:

```
Error: Could not parse jison grammar
```

After:

```
Error: Parse error on line 86:
...   ;expatom    = atom '^' nat
--------------------^
Expecting ':', got 'ID'
```
