### PR TITLE
More details from parsing Error

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1358,7 +1358,13 @@ function parseError (str, hash) {
     if (hash.recoverable) {
         this.trace(str);
     } else {
-        throw new Error(str);
+        function _parseError (msg, hash) {
+            this.message = msg;
+            this.hash = hash;
+        }
+        _parseError.prototype = new Error();
+
+        throw new _parseError(str, hash);
     }
 }
 


### PR DESCRIPTION
Include the information from hash to better handle client-side reporting when raising a parseError.