### PR TITLE
Fix this.lexer undefined, fixes #246

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1338,6 +1338,7 @@ lrGeneratorMixin.createParser = function createParser () {
     }
 
     // backwards compatability
+    p.lexer = this.lexer;
     p.generate = bind('generate');
     p.generateAMDModule = bind('generateAMDModule');
     p.generateModule = bind('generateModule');


### PR DESCRIPTION
It seems that 9e0cc65 introduced a bug in the generated
code, such that `this.lexer` is undefined, and so it
throws a runtime error.

This fixes the bug, and also adds a test to reproduce the
error. The test fails before the fix, but succeeds after.
I ran the tests and confirmed 100% success and no errors.