### PR TITLE
add "happy happy" as an example grammar

### DIFF
--- a/web/jison/examples/happyhappy.jison
+++ b/web/jison/examples/happyhappy.jison
@@ -1,0 +1,43 @@
+// Simple "happy happy joy joy" parser, written by Nolan Lawson.
+// Based on the song of the same name.
+// Valid sentences in this language include:
+//
+// "happy happy joy joy"
+// "happy happy joy joy happy happy joy joy"
+// "happy happy joy joy joy"
+//
+
+%lex
+%
+
+\s+                   /* skip whitespace */
+
+// the enclosing parentheses ensure that word boundaries don't matter
+("happy")             return 'happy'
+("joy")               return 'joy'
+<<EOF>>               return 'EOF'
+
+/lex
+
+%start expressions
+
+// ENBF is used in order to give us syntax goodies
+// like '+' and '*' repeaters, groups with '(' ')', etc.
+%ebnf
+
+%
+
+expressions
+    : e EOF
+        {return $1;}
+    ;
+
+// yytext means the whole text
+// the -> notation is shorthand for {{ $$ = whatever }}
+e
+    : phrase+ 'joy'? -> $1 + ' ' + yytext
+    ;
+
+phrase
+    : 'happy' 'happy' 'joy' 'joy'  -> [$1, $2, $3, $4].join(' ');
+    ;


### PR DESCRIPTION
I wanted to add my simple "happy happy joy joy" grammar to the "Try" page, as an example of pretty much the simplest grammar I could think of. It's also heavily annotated, to give some clues about tricks like EBNF, the `->` notation, etc.

I noticed, though, that the current docs in the `web/` directory aren't the same as what's reflected on the website. Furthermore, the docs aren't building when I run `nanoc`; the lambda calculus example doesn't load anymore, and the `jison.js` file itself is 404'ing. Also, there are two `examples/` directories for some reason? One in the root and one in `web/jison`?

So I'm wondering; are the docs in flux, or did they get mangled and nobody's gotten around to fixing them, or...? I'm happy to help out, but I'm just wondering about the current state of things.