### PR TITLE
Use local uglifyjs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: test
 
 site:
-	./node_modules/.bin/browserify entry.js --exports require | uglifyjs > web/content/assets/js/jison.js
+	./node_modules/.bin/browserify entry.js --exports require | ./node_modules/.bin/uglifyjs > web/content/assets/js/jison.js
 	cd web/ && nanoc compile
 	cp -r examples web/output/jison/
 


### PR DESCRIPTION
It's safer to use the local in node_modules, so that
developers don't need to have uglifyjs installed
globally.