### PR TITLE
Fix issue #276, error when input file is JSON format.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,9 +68,7 @@ cli.main = function cliMain(opts) {
     function processGrammar(raw, lex, opts) {
         var grammar,
         parser;
-        if (!opts.json) {
-            grammar = cli.processGrammars(raw, lex, opts.json);
-        }
+        grammar = cli.processGrammars(raw, lex, opts.json);
         parser = cli.generateParserString(opts, grammar);
         return parser;
     }


### PR DESCRIPTION
In original version, when input file is JSON format, `opts.json` is `true` so that `processGrammars` will not be called, which makes variable `grammar` to be undefined...
Just fix it.