### PR TITLE
made moduleName valid

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -144,6 +144,9 @@ cli.generateParserString = function generateParserString(opts, grammar) {
     if (opts['parser-type']) {
         settings.type = opts['parser-type'];
     }
+    if (opts.moduleName) {
+        settings.moduleName = opts.moduleName;
+    }
     settings.debug = opts.debug;
     if (!settings.moduleType) {
         settings.moduleType = opts['module-type'];


### PR DESCRIPTION
In cli.js, there are codes to define moduleName, but it was not effective.
So I took it to settings for jison.Generator.
