### PR TITLE
Add a license property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "jison",
   "description": "A parser generator with Bison's API",
   "version": "0.4.15",
+  "license": "MIT",
   "keywords": [
     "jison",
     "bison",


### PR DESCRIPTION
Add the SPDX-compliant license identifier for the MIT license, "MIT", as the "license" property in `package.json`. This makes it possible for programs to determine how jison is licensed, without attempting inference from README.