### PR TITLE
Fix moduleName (and other options?) being lost

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -139,7 +139,7 @@ cli.generateParserString = function generateParserString(opts, grammar) {
     opts = opts || {};
     var jison = require('./jison.js');
 
-    var settings = grammar.options || {};
+    var settings = grammar.options || opts;
 
     if (opts['parser-type']) {
         settings.type = opts['parser-type'];


### PR DESCRIPTION
This bug is mentioned in https://github.com/zaach/jison/commit/cf9346cb5019abe026dafd1a02d876b00f20bd9c#commitcomment-10419124