### PR TITLE
Fixing strict mode function decleration error

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1422,7 +1422,7 @@ parser.parse = function parse (input) {
     }
 
 _token_stack:
-    function lex() {
+    var lex = function () {
         var token;
         token = lexer.lex() || EOF;
         // if token isn't its numeric value, convert


### PR DESCRIPTION
Simple proposd fix for issue #285 
tests pass and it seems to work with browserify and babel.