### PR TITLE
output of parser error to console in debug mode

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,7 +68,7 @@ cli.main = function cliMain(opts) {
     function processGrammar(raw, lex, opts) {
         var grammar,
         parser;
-        grammar = cli.processGrammars(raw, lex, opts.json);
+        grammar = cli.processGrammars(raw, lex, opts.json, opts.debug);
         parser = cli.generateParserString(opts, grammar);
         return parser;
     }
@@ -154,7 +154,7 @@ cli.generateParserString = function generateParserString(opts, grammar) {
     return generator.generate(settings);
 };
 
-cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
+cli.processGrammars = function processGrammars(file, lexFile, jsonMode, debugMode) {
     "use strict";
     lexFile = lexFile || false;
     jsonMode = jsonMode || false;
@@ -168,6 +168,9 @@ cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
             grammar = ebnfParser.parse(file);
         }
     } catch (e) {
+        if (debugMode === true) {
+            console.log(e);
+        }
         throw new Error('Could not parse jison grammar');
     }
     try {
@@ -175,6 +178,9 @@ cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
             grammar.lex = require('lex-parser').parse(lexFile);
         }
     } catch (e) {
+        if (debugMode === true) {
+            console.log(e);
+        }
         throw new Error('Could not parse lex grammar');
     }
     return grammar;


### PR DESCRIPTION
The output of the CLI is a bit sparse in case of parsing errors and does not change with the `-t` option. I know of at least one other try but my proposal keeps the proper error-handling and just adds some console output in case the `-t` option has been given. There are way to many chances to add a little typo in a large grammar and a bit of an increased verbosity on commaned would certainly help a lot in such cases. And others.