### PR TITLE
Added JSONNullLiteral to json.js example

### DIFF
--- a/examples/json.js
+++ b/examples/json.js
@@ -33,6 +33,8 @@ exports.grammar = {
 
     "bnf": {
         "JSONString": [ "STRING" ],
+        
+        "JSONNullLiteral": [ "NULL" ],
 
         "JSONNumber": [ "NUMBER" ],
 


### PR DESCRIPTION
The `"JSONNullLiteral": [ "NULL" ]` was forgotten in `"bnf"` section, and `null` didn't parse.