### PR TITLE
Pass moduleMain option to generator

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -145,6 +145,9 @@ cli.generateParserString = function generateParserString(opts, grammar) {
     if (opts.moduleName) {
         settings.moduleName = opts.moduleName;
     }
+    if (opts.moduleMain) {
+        settings.moduleMain = opts.moduleMain;
+    }
     settings.debug = opts.debug;
     if (!settings.moduleType) {
         settings.moduleType = opts['module-type'];


### PR DESCRIPTION
Allows using the `--moduleMain` argument with the command-line interface, to define an alternate `exports.main` implementation.

Without this change, it is only possible (as far as I can tell) to set `moduleMain` through the module API but not the CLI. (You can also specify `%option moduleMain` in the grammar jison input file, but it generates invalid JavaScript then - only appears to be possible set it to "true", but a function is required).

Tested this change with `make test`, all pass