### PR TITLE
Fix throwing of parseError

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1363,7 +1363,7 @@ function parseError (str, hash) {
             this.message = msg;
             this.hash = hash;
         }
-        _parseError.prototype = new Error();
+        _parseError.prototype = Error;
 
         throw new _parseError(str, hash);
     }


### PR DESCRIPTION
The constructor is set to `new Error()`, instead set it to just
`Error`.

Fixes #318.