### PR TITLE
Add detail grammar error output

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -168,6 +168,7 @@ cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
             grammar = ebnfParser.parse(file);
         }
     } catch (e) {
+        console.log(e);
         throw new Error('Could not parse jison grammar');
     }
     try {
@@ -175,6 +176,7 @@ cli.processGrammars = function processGrammars(file, lexFile, jsonMode) {
             grammar.lex = require('lex-parser').parse(lexFile);
         }
     } catch (e) {
+        console.log(e);
         throw new Error('Could not parse lex grammar');
     }
     return grammar;


### PR DESCRIPTION
Add detail grammar error output, which will help developer find the yacc
grammar error quickly.

The current version will only show an error with a single text, which is not friendly.