### PR TITLE
Improve test for CommonJS environment

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -966,7 +966,7 @@ lrGeneratorMixin.generateCommonJSModule = function generateCommonJSModule (opt) 
     opt = typal.mix.call({}, this.options, opt);
     var moduleName = opt.moduleName || "parser";
     var out = this.generateModule(opt)
-        + "\n\n\nif (typeof require !== 'undefined' && typeof exports !== 'undefined') {"
+        + "\n\n\nif (typeof require !== 'undefined' && typeof exports !== 'undefined' && new Function('try{return this===global;}catch(e){return false;}')()) {"
         + "\nexports.parser = "+moduleName+";"
         + "\nexports.Parser = "+moduleName+".Parser;"
         + "\nexports.parse = function () { return "+moduleName+".parse.apply("+moduleName+", arguments); };"


### PR DESCRIPTION
`lrGeneratorMixin.generateCommonJSModule` generates some code that tries to detect whether we’re running in a CommonJS environment, but its test isn’t as robust as it could be. Its method is to check if `require` and `exports` are defined, but a common use case where those might be defined in a non-CommonJS environment would be a project that uses require.js. This leads to issues such as https://github.com/jashkenas/coffeescript/issues/4391.

In addition to checking for global `require` and `exports`, I added a check that the global `this` object is `global`, per http://stackoverflow.com/a/31090240/223225. This should rule out all browsers, whose global `this` object is `window`, and therefore the following code (including `require('fs')` should only run in a true Node CommonJS environment.