### PR TITLE
Always remove the token stack label

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1092,10 +1092,14 @@ function addTokenStack (fn) {
 
         labeled[0].body = stackAst;
 
-        return escodegen.generate(ast).replace(/_token_stack:\s?/,"").replace(/\\\\n/g,"\\n");
+        return escodegen.generate(ast);
     } catch (e) {
         return parseFn;
     }
+}
+
+function removeTokenStackLabel(code) {
+    return code.replace(/_token_stack:\s?/,"").replace(/\\\\n/g,"\\n");
 }
 
 // lex function that supports token stacks
@@ -1143,6 +1147,8 @@ lrGeneratorMixin.generateModule_ = function generateModule_ () {
     if (this.options['token-stack']) {
       parseFn = addTokenStack(parseFn);
     }
+    
+    parseFn = removeTokenStackLabel(parseFn);
 
     // Generate code with fresh variable names
     nextVariableId = 0;


### PR DESCRIPTION
_token_stack label was only removed when `token-stack` option was present.