### PR TITLE
Fix issue where the location of the past lexer input is reported on error

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1493,7 +1493,7 @@ _handle_error:
                     text: lexer.match,
                     token: this.terminals_[symbol] || symbol,
                     line: lexer.yylineno,
-                    loc: yyloc,
+                    loc: lexer.yylloc,
                     expected: expected,
                     recoverable: (error_rule_depth !== false)
                 });

--- a/ports/comments.js
+++ b/ports/comments.js
@@ -142,7 +142,7 @@ parse: function parse(input) {
                 } else {
                     errStr = "Parse error on line " + (yylineno + 1) + ": Unexpected " + (symbol == 1?"end of input":"'" + (this.terminals_[symbol] || symbol) + "'");
                 }
-                this.parseError(errStr, {text: this.lexer.match, token: this.terminals_[symbol] || symbol, line: this.lexer.yylineno, loc: yyloc, expected: expected});
+                this.parseError(errStr, {text: this.lexer.match, token: this.terminals_[symbol] || symbol, line: this.lexer.yylineno, loc: this.lexer.yylloc, expected: expected});
             }
         }
         if (action[0] instanceof Array && action.length > 1) {

--- a/ports/csharp/Jison/Jison/Test/formula.js
+++ b/ports/csharp/Jison/Jison/Test/formula.js
@@ -696,7 +696,7 @@ _handle_error:
 						text: this.lexer.match,
 						token: this.terminals_[symbol] || symbol,
 						line: this.lexer.yylineno,
-						loc: yyloc,
+						loc: this.lexer.yylloc,
 						expected: expected,
                         recoverable: (error_rule_depth !== false)
 				});


### PR DESCRIPTION
This takes care of an issue where the location of an error is reported for the previous input of the lexer and not of the actual text that causes the error.