### PR TITLE
Modified cli.js to accept a -n parameter to set the module name used in gene…

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,6 +32,11 @@ function getCommandlineOptions () {
             false,
             help : 'Debug mode'
         })
+        .option('module-name', {
+            abbr : 'n',
+            metavar : 'string',
+            help : 'The name of the module to generate, otherwise the base name of the outfile will be used '
+        })
         .option('module-type', {
             abbr : 'm',
         default:
@@ -94,8 +99,9 @@ cli.main = function cliMain(opts) {
         name = name.replace(/\..*$/g, '');
 
         opts.outfile = opts.outfile || (name + '.js');
-        if (!opts.moduleName && name) {
-            opts.moduleName = name.replace(/-\w/g,
+
+        if (!opts['module-name'] && name) {
+            opts['module-name'] = name.replace(/-\w/g,
                     function (match) {
                     return match.charAt(1).toUpperCase();
                 });
@@ -142,8 +148,8 @@ cli.generateParserString = function generateParserString(opts, grammar) {
     if (opts['parser-type']) {
         settings.type = opts['parser-type'];
     }
-    if (opts.moduleName) {
-        settings.moduleName = opts.moduleName;
+    if (opts['module-name']) {
+        settings.moduleName = opts['module-name'];
     }
     settings.debug = opts.debug;
     if (!settings.moduleType) {


### PR DESCRIPTION
…rating a parser

Had a situation where i needed to specify the module name on the command line, so I modified cli.js. thoight someone else might also need this at some point.