### PR TITLE
Generate valid "strict mode" javascript

### DIFF
--- a/lib/jison.js
+++ b/lib/jison.js
@@ -1452,7 +1452,7 @@ _handle_error:
 
             // Return the rule stack depth where the nearest error rule can be found.
             // Return FALSE when no error recovery rule was found.
-            function locateNearestErrorRecoveryRule(state) {
+            var locateNearestErrorRecoveryRule = function(state) {
                 var stack_probe = stack.length - 1;
                 var depth = 0;
 


### PR DESCRIPTION
In strict mode code, functions can only be declared at the top level or immediately within another function. With this commit `locateNearestErrorRecoveryRule` is declared as a variable and assigned a function instead of being declared as a named function.

With this PR one can include the generated file directly in a `"use strict";` setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaach/jison/373)
<!-- Reviewable:end -->
