### PR TITLE
✨ Add new calculator example with variable support

### DIFF
--- a/examples/calculator2.jison
+++ b/examples/calculator2.jison
@@ -1,0 +1,75 @@
+
+/* description: Parses and executes mathematical expressions. Added support for variable evaluation. */
+
+/* lexical grammar */
+%lex
+%%
+
+\s+                       /* skip whitespace */
+[a-zA-Z_][a-zA-Z0-9_]*    return 'VARIABLE'
+[0-9]+("."[0-9]+)?\b      return 'NUMBER'
+"*"                       return '*'
+"/"                       return '/'
+"-"                       return '-'
+"+"                       return '+'
+"^"                       return '^'
+"!"                       return '!'
+"%"                       return '%'
+"("                       return '('
+")"                       return ')'
+"PI"                      return 'PI'
+"E"                       return 'E'
+<<EOF>>                   return 'EOF'
+.                         return 'INVALID'
+
+/lex
+
+/* operator associations and precedence */
+
+%left '+' '-'
+%left '*' '/'
+%left '^'
+%right '!'
+%right '%'
+%left UMINUS
+
+%start expressions
+
+%% /* language grammar */
+
+expressions
+    : e EOF
+        { typeof console !== 'undefined' ? console.log($1) : print($1);
+          return $1; }
+    ;
+
+e
+    : e '+' e
+        {$$ = $1+$3;}
+    | e '-' e
+        {$$ = $1-$3;}
+    | e '*' e
+        {$$ = $1*$3;}
+    | e '/' e
+        {$$ = $1/$3;}
+    | e '^' e
+        {$$ = Math.pow($1, $3);}
+    | e '!'
+        {{
+          $$ = (function fact (n) { return n==0 ? 1 : fact(n-1) * n })($1);
+        }}
+    | e '%'
+        {$$ = $1/100;}
+    | '-' e %prec UMINUS
+        {$$ = -$2;}
+    | '(' e ')'
+        {$$ = $2;}
+    | VARIABLE
+        { $$ = yy[yytext]; }
+    | NUMBER
+        {$$ = Number(yytext);}
+    | E
+        {$$ = Math.E;}
+    | PI
+        {$$ = Math.PI;}
+    ;

--- a/examples/calculator2.jison
+++ b/examples/calculator2.jison
@@ -65,7 +65,7 @@ e
     | '(' e ')'
         {$$ = $2;}
     | VARIABLE
-        { $$ = yy[yytext]; }
+        {$$ = yy[yytext];}
     | NUMBER
         {$$ = Number(yytext);}
     | E


### PR DESCRIPTION
This PR adds a new calculator example (`examples/calculator2.jison`) that supports variable evaluation.

It is based on the original example [`calculator.jison`](https://github.com/zaach/jison/blob/master/examples/calculator.jison) and adds only following:
```jison
// Variable name RegEx
[a-zA-Z_][a-zA-Z0-9_]*    return 'VARIABLE'

...

// Parse variable value
| VARIABLE
    { $$ = yy[yytext]; }
```