### PR TITLE
Fix broken link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ parser.parse("adfe34bc zxg");
 
 More Documentation
 ------------------
-For more information on creating grammars and using the generated parsers, read the [documentation](http://jison.org/docs).
+For more information on creating grammars and using the generated parsers, read the [documentation](https://gerhobbelt.github.io/jison/docs/).
 
 How to contribute
 -----------------


### PR DESCRIPTION
The link to the documentation in the README is broken.
I put the one I believe is correct